### PR TITLE
Remove the jekyll-front-matter comment scrubber

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -124,11 +124,8 @@ function relocate_file() {
   sed -e "s!href=\"${BASE_URL}!href=\"{{site.baseurl}}!g" \
     -e "s!\][(]${BASE_URL}!]({{home}}!g" ${FILENAME} > "${OUT_PATH}"
   # If an md file, replace header links that use _ spacing with -.
-  # Also remove jekyll-front-matter comment wrappers.
   if [[ "${FILENAME}" = *.md ]]; then
     sed -i -e ':a' -e 's/\(][(]#[^)_]*\)_/\1-/;t a' \
-      -e '/^\s*<!--jekyll-front-matter/d' \
-      -e '/^\s*jekyll-front-matter-->/d' \
       "${OUT_PATH}"
   fi
 


### PR DESCRIPTION
The jekyll front-matter comments are not necessary to remove since they're no longer in the source material.