### PR TITLE
Add relocate_images to build.sh

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,6 +4,7 @@ from debian:buster
 RUN apt-get update && \
     apt-get install -y \
         doxygen \
+        gawk \
         git \
 	graphviz \
         golang \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -130,3 +130,35 @@ location: /_about/about.md
 
 Do not add `redirect_from: /about/about.html` for this file because it will
 create a redirect loop.
+
+### Markdown image dependencies
+
+Markdown has an image embedding directive, `![Caption](url)`, that is not
+appropriate for the website. The alternative image placement markup states more
+specific information about size and ratios. Therefore the `build.sh` script
+interprets some comments related to image embeddings to replace
+`![Caption](url)` with a user-provided replacement. Additionally, since docs are
+sourced from the Asylo repo, the images are copied from their source path to a
+stated destination.
+
+```markdown
+<!--asylo:image-replace-begin(destination-path-relative-to-destination-doc)-->
+
+![Caption](source-path-relative-to-source-doc)
+<!--asylo:image-replace-with[...]-->
+```
+
+The `[...]` is any text you want, except `$destination` and `$description` will
+be replaced with `destination-path-relative-to-destination-doc` and `Caption`
+respectively, and newlines are unsupported.
+
+Example from the website:
+
+```markdown
+<!--asylo:image-replace-begin(./img/asylo.png)-->
+
+![Asylo architecture](images/asylo.png)
+<!--asylo:image-replace-with {% include figure.html width='80%' ratio='46.36%' img='$destination' alt='$description' title='$description' caption='$description' %} -->
+```
+
+The `-a` option to `build.sh` additionally applies to the relocated image files.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -137,7 +137,7 @@ function relocate_images() {
     git_add_destination="system(${git_add_command})"
   fi
   local transformed=$(mktemp)
-  awk "{
+  gawk "{
   if (\$0 ~ ${begin_re}) {
     destination = gensub(${begin_re}, \"\\\\1\", 1, \$0);
     do { getline; } while (\$0 ~ /^\\s*\$/);


### PR DESCRIPTION
This addition to build.sh interprets a markdown image directive as
alternative text and relocates the source image to a destination path.
The alternative text may have the initial description and the stated
destination values interpolated into the replacement text as
$description and $destination.

Documentation that references images may now have their dependencies
forwarded to the right website location.

The downside to this change is that each <!-- ... --> comment must be single-line. This can mean very long lines in sources. I haven't yet found this limitation to be too burdensome.

This has been tested on the typical build workflow with image relocation
directives added to api-overview.md and overview.md.