### PR TITLE
Fix relative path sources for general image relocation.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -140,12 +140,13 @@ function relocate_images() {
   local out_file="$2"
   local out_dir="$3"
   local replace_re='/(.*)<!--\s*asylo:image-replace-with(.*)-->(.*)/'
-  local begin_move_re='/<!--\s*asylo:image-replace-begin\(([^=)]*)\s*=>\s([^)]*)*\)-->/'
+  local begin_move_re='/<!--\s*asylo:image-replace-begin\(([^=) ]*)\s*=>\s*([^)]*)*\)-->/'
   local begin_re='/<!--\s*asylo:image-replace-begin\(([^)]*)\)-->/'
   local source_re='/!\[(.*)\]\((.*)\)/'
+  local full_source=$(printf '\\"%s/\" source "\\"' "${ASYLO_LOCATION}/${source_dir}")
   local full_destination=$(printf '\\"%s/\" destination "\\"' "${out_dir}")
   local mkdir_command=$(printf '"mkdir -p $(dirname %s)"' "${full_destination}")
-  local copy_command=$(printf '"cp " source " %s"' "${full_destination}")
+  local copy_command=$(printf '"cp %s %s"' "${full_source}" "${full_destination}")
   local git_add_destination=
   local git_add_command=
   if [[ -n "${GIT_ADD}" ]]; then


### PR DESCRIPTION
The source path was relative to the site rather than the location of the original document, so this fixes that.

The regex grouping for the source was also too greedy and matched whitespace before the =>, causing the quoted path to be "image.png " rather than "image.png". The regex has been fixed.